### PR TITLE
docs: wire MCP Server page into sidebar, guide, and API overview

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,5 +14,13 @@ export default {
         link: '/guide/'
       },
     ],
+    sidebar: [
+      '/guide/',
+      '/formester-api',
+      '/formester-api-v1',
+      '/formester-api-v2',
+      '/paypal-integration',
+      '/formester-mcp-server',
+    ],
   }),
 } 

--- a/docs/formester-api.md
+++ b/docs/formester-api.md
@@ -24,6 +24,17 @@ Multi-form integrations
 
 </td>
 </tr>
+<tr>
+<td width="50%" align="center">
+
+### [🤖 MCP Server](./formester-mcp-server.md)
+**AI agent integration**
+Connect Claude, GPT-4, and any MCP-compatible model directly to your submissions
+
+</td>
+<td width="50%" align="center">
+</td>
+</tr>
 </table>
 
 ---
@@ -39,5 +50,6 @@ Multi-form integrations
 
 - **For v1**: Contact our support team at [support@formester.com](mailto:support@formester.com) to obtain your token.
 - **For v2**: Visit [app.formester.com/api](https://app.formester.com/api) in your Formester dashboard to generate your token.
+- **For MCP**: See the [MCP Server guide](./formester-mcp-server.md) to connect AI agents directly to your submissions.
 
 For new integrations, we recommend starting with API v2.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,2 +1,3 @@
 ## [PayPal Integration with Formester](/paypal-integration)
 ## [Introduction to Formester API](/formester-api)
+## [Formester MCP Server](/formester-mcp-server)


### PR DESCRIPTION
## Summary

Follow-up to #4 — the MCP doc file was merged but wasn't registered in VuePress navigation, so it wasn't showing up on docs.formester.com.

Changes:
- `config.js` — added `formester-mcp-server` to the VuePress sidebar array
- `guide.md` — added MCP Server link alongside PayPal and API entries
- `formester-api.md` — added MCP Server card in the API overview table

🤖 Generated with [Claude Code](https://claude.com/claude-code)